### PR TITLE
Jenkinsfile: use dumb-init

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
          - name: coreos-assembler
            image: docker-registry.default.svc:5000/fedora-coreos/coreos-assembler:master
            imagePullPolicy: Always
-           command: ['/bin/bash']
-           args: ['-c', 'sleep infinity']
+           command: ['/usr/bin/dumb-init']
+           args: ['sleep', 'infinity']
            volumeMounts:
            - name: data
              mountPath: /srv/


### PR DESCRIPTION
Otherwise, I've got a bunch of defunct qemu-kvm processes and the final
`qemu-kvm` from `virt-install` just hangs at
`reboot: Restarting system`. Not sure why prod isn't hitting this.