### PR TITLE
pipeline: always sync in state from prod first

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,40 @@ node {
 }
 
 def shwrap(cmds) {
-  sh """
-    set -xeuo pipefail
-    cd /srv
-    ${cmds}
-  """
+    sh """
+        set -xeuo pipefail
+        cd /srv
+        ${cmds}
+    """
+}
+
+def rsync(from, to) {
+
+    def rsync_keypath = "/var/run/secrets/kubernetes.io/duffy-key/duffy.key"
+    if (!fileExists(rsync_keypath)) {
+        echo "No ${rsync_keypath} file with rsync key."
+        echo "Must be operating in dev environment"
+        echo "Skipping rsync...."
+        return
+    }
+
+    def rsync_key = readFile(file: rsync_keypath)
+    rsync_key = rsync_key[0..12]
+
+    shwrap("""
+    # so we don't echo password to the jenkins logs
+    set +x; export RSYNC_PASSWORD=${rsync_key}; set -x
+    # always add trailing slash for consistent semantics
+    rsync -avh --delete ${from}/ ${to}
+    """)
+}
+
+def rsync_in(from, to) {
+    rsync("fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${from}", "${to}")
+}
+
+def rsync_out(from, to) {
+    rsync("${from}", "fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${to}")
 }
 
 podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultContainer: 'jnlp') {
@@ -34,27 +63,17 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
         stage('Archive') {
             shwrap("""
-            keyfile=/var/run/secrets/kubernetes.io/duffy-key/duffy.key
-            if [ ! -f \$keyfile ]; then
-                echo "No \$keyfile file with rsync key."
-                echo "Must be operating in dev environment"
-                echo "Skipping rsync...."
-                exit 0
-            fi
-            set +x # so we don't echo password to the jenkins logs
-            RSYNC_PASSWORD=\$(cat \$keyfile)
-            export RSYNC_PASSWORD=\${RSYNC_PASSWORD:0:13}
-            set -x
             # Change perms to allow reading on webserver side.
             # Don't touch symlinks (https://github.com/CentOS/sig-atomic-buildscripts/pull/355)
             find builds/ ! -type l -exec chmod a+rX {} +
             find repo/   ! -type l -exec chmod a+rX {} +
-            # Note that if the prod directory doesn't exist on the remote this
-            # will fail. We can possibly hack around this in the future:
-            # https://stackoverflow.com/questions/1636889/rsync-how-can-i-configure-it-to-create-target-directory-on-server
-            rsync -avh --delete ./builds/ fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/builds/
-            rsync -avh --delete ./repo/   fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/repo/
             """)
+
+            // Note that if the prod directory doesn't exist on the remote this
+            // will fail. We can possibly hack around this in the future:
+            // https://stackoverflow.com/questions/1636889
+            rsync_out("builds", "builds")
+            rsync_out("repo", "repo")
         }
     }}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,68 +1,32 @@
-def pod
+def pod, utils
 node {
     checkout scm
     pod = readFile(file: "manifests/pod.yaml")
-}
-
-def shwrap(cmds) {
-    sh """
-        set -xeuo pipefail
-        cd /srv
-        ${cmds}
-    """
-}
-
-def rsync(from, to) {
-
-    def rsync_keypath = "/var/run/secrets/kubernetes.io/duffy-key/duffy.key"
-    if (!fileExists(rsync_keypath)) {
-        echo "No ${rsync_keypath} file with rsync key."
-        echo "Must be operating in dev environment"
-        echo "Skipping rsync...."
-        return
-    }
-
-    def rsync_key = readFile(file: rsync_keypath)
-    rsync_key = rsync_key[0..12]
-
-    shwrap("""
-    # so we don't echo password to the jenkins logs
-    set +x; export RSYNC_PASSWORD=${rsync_key}; set -x
-    # always add trailing slash for consistent semantics
-    rsync -avh --delete ${from}/ ${to}
-    """)
-}
-
-def rsync_in(from, to) {
-    rsync("fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${from}", "${to}")
-}
-
-def rsync_out(from, to) {
-    rsync("${from}", "fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${to}")
+    utils = load("utils.groovy")
 }
 
 podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultContainer: 'jnlp') {
     node('coreos-assembler') { container('coreos-assembler') {
         stage('Init') {
-            shwrap("""
+            utils.shwrap("""
             if [ ! -d src/config ]; then
                 coreos-assembler init https://github.com/coreos/fedora-coreos-config
             fi
             """)
         }
         stage('Fetch') {
-            shwrap("""
+            utils.shwrap("""
             git -C src/config pull
             coreos-assembler fetch
             """)
         }
         stage('Build') {
-            shwrap("""
+            utils.shwrap("""
             coreos-assembler build
             """)
         }
         stage('Archive') {
-            shwrap("""
+            utils.shwrap("""
             # Change perms to allow reading on webserver side.
             # Don't touch symlinks (https://github.com/CentOS/sig-atomic-buildscripts/pull/355)
             find builds/ ! -type l -exec chmod a+rX {} +
@@ -72,8 +36,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             // Note that if the prod directory doesn't exist on the remote this
             // will fail. We can possibly hack around this in the future:
             // https://stackoverflow.com/questions/1636889
-            rsync_out("builds", "builds")
-            rsync_out("repo", "repo")
+            utils.rsync_out("builds", "builds")
+            utils.rsync_out("repo", "repo")
         }
     }}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,10 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             """)
         }
         stage('Fetch') {
+            // make sure our cached version matches prod exactly before continuing
+            utils.rsync_in("repo", "repo")
+            utils.rsync_in("builds", "builds")
+
             utils.shwrap("""
             git -C src/config pull
             coreos-assembler fetch

--- a/utils.groovy
+++ b/utils.groovy
@@ -1,0 +1,38 @@
+def shwrap(cmds) {
+    sh """
+        set -xeuo pipefail
+        cd /srv
+        ${cmds}
+    """
+}
+
+def rsync(from, to) {
+
+    def rsync_keypath = "/var/run/secrets/kubernetes.io/duffy-key/duffy.key"
+    if (!fileExists(rsync_keypath)) {
+        echo "No ${rsync_keypath} file with rsync key."
+        echo "Must be operating in dev environment"
+        echo "Skipping rsync...."
+        return
+    }
+
+    def rsync_key = readFile(file: rsync_keypath)
+    rsync_key = rsync_key[0..12]
+
+    shwrap("""
+    # so we don't echo password to the jenkins logs
+    set +x; export RSYNC_PASSWORD=${rsync_key}; set -x
+    # always add trailing slash for consistent semantics
+    rsync -avh --delete ${from}/ ${to}
+    """)
+}
+
+def rsync_in(from, to) {
+    rsync("fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${from}", "${to}")
+}
+
+def rsync_out(from, to) {
+    rsync("${from}", "fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${to}")
+}
+
+return this


### PR DESCRIPTION
The basic issue this patch is trying to fix is our overdependence on the
PVC; right now, if the PVC gets wiped, the next build will reset the
versioning and delete all the previous builds in prod.

So an easy way to fix this is simply to make sure that the PVC is in the
same state as the prod version. This should be a no-op normally, except
if the PVC got wiped.

Eventually, we should think about higher-level "release" management such
as how many builds to keep and whether to push smoketested images to
e.g. S3 or something (and instead treat artifacts.ci.centos.org/ as a
"buildmaster" pipeline), etc...