### PR TITLE
pipeline: decorate builds and exit early if no changes

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -6,6 +6,22 @@ def shwrap(cmds) {
     """
 }
 
+def shwrap_capture(cmds) {
+    return sh(returnStdout: true, script: """
+        set -euo pipefail
+        cd /srv
+        ${cmds}
+    """).trim()
+}
+
+def shwrap_rc(cmds) {
+    return sh(returnStatus: true, script: """
+        set -euo pipefail
+        cd /srv
+        ${cmds}
+    """)
+}
+
 def rsync(from, to) {
 
     def rsync_keypath = "/var/run/secrets/kubernetes.io/duffy-key/duffy.key"


### PR DESCRIPTION
First, learn to read what the previous build was and then skip the rsync
out stage if there are no new builds.

Second, decorate build descriptions of new builds with their build ID or
otherwise, just say no changes. This makes it easy at a glance to find
out which jobs created new builds.